### PR TITLE
Make widget types match functions

### DIFF
--- a/src/Widget.elm
+++ b/src/Widget.elm
@@ -276,7 +276,7 @@ multiSelect =
 -}
 type alias Dialog msg =
     { title : Maybe String
-    , body : Element msg
+    , text : String
     , accept : Maybe (TextButton msg)
     , dismiss : Maybe (TextButton msg)
     }
@@ -321,8 +321,6 @@ type alias ExpansionPanel msg =
     { onToggle : Bool -> msg
     , icon : Element Never
     , text : String
-    , expandIcon : Element Never
-    , collapseIcon : Element Never
     , content : Element msg
     , isExpanded : Bool
     }


### PR DESCRIPTION
Make Dialog and ExpansionPanel type aliases match the dialog and expansionPanel function signatures.