### PR TITLE
Add Progress Indicators

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ _Please only open Pull Requests for existing issues._
 
 **Optional:**
 * [ ] Added a Material design style in `src/Widget/Style/Material.elm`
-* [ ] Added a Ellie to the docs (+ copied it into `example/src/Example/[Your Widget].elm`)
+* [ ] Added an Example in `example/src/Example/[Your Widget].elm`

--- a/example/src/Data/Example.elm
+++ b/example/src/Data/Example.elm
@@ -82,7 +82,7 @@ toString example =
             "List"
 
         ProgressIndicatorExample ->
-            "ProgressIndicator"
+            "Progress Indicator"
 
 
 fromString : String -> Maybe Example

--- a/example/src/Data/Example.elm
+++ b/example/src/Data/Example.elm
@@ -8,6 +8,7 @@ import Example.ExpansionPanel as ExpansionPanel
 import Example.List as List
 import Example.Modal as Modal
 import Example.MultiSelect as MultiSelect
+import Example.ProgressIndicator as ProgressIndicator
 import Example.Select as Select
 import Example.SortTable as SortTable
 import Example.Tab as Tab
@@ -27,6 +28,7 @@ type Example
     | DialogExample
     | TextInputExample
     | ListExample
+    | ProgressIndicatorExample
 
 
 asList : List Example
@@ -41,6 +43,7 @@ asList =
     , DialogExample
     , TextInputExample
     , ListExample
+    , ProgressIndicatorExample
     ]
         |> List.sortBy toString
 
@@ -78,6 +81,9 @@ toString example =
         ListExample ->
             "List"
 
+        ProgressIndicatorExample ->
+            "ProgressIndicator"
+
 
 fromString : String -> Maybe Example
 fromString string =
@@ -111,6 +117,9 @@ fromString string =
 
         "List" ->
             Just ListExample
+
+        "Progress Indicator" ->
+            Just ProgressIndicatorExample
 
         _ ->
             Nothing
@@ -149,6 +158,9 @@ get example =
         ListExample ->
             .list
 
+        ProgressIndicatorExample ->
+            .progressIndicator
+
 
 toTests : Example -> msg -> Style msg -> List ( String, Element msg )
 toTests example =
@@ -183,6 +195,9 @@ toTests example =
         ListExample ->
             Test.list
 
+        ProgressIndicatorExample ->
+            Test.progressIndicator
+
 
 type Msg
     = Button Button.Msg
@@ -195,6 +210,7 @@ type Msg
     | Dialog Dialog.Msg
     | TextInput TextInput.Msg
     | List List.Msg
+    | ProgressIndicator ProgressIndicator.Msg
 
 
 type alias Model =
@@ -208,6 +224,7 @@ type alias Model =
     , dialog : Dialog.Model
     , textInput : TextInput.Model
     , list : List.Model
+    , progressIndicator : ProgressIndicator.Model
     }
 
 
@@ -231,6 +248,7 @@ type alias UpgradeCollection =
     , dialog : UpgradeRecord Dialog.Model Dialog.Msg
     , textInput : UpgradeRecord TextInput.Model TextInput.Msg
     , list : UpgradeRecord List.Model List.Msg
+    , progressIndicator : UpgradeRecord ProgressIndicator.Model ProgressIndicator.Msg
     }
 
 
@@ -245,6 +263,7 @@ type alias ExampleView msg =
     , dialog : Element msg
     , textInput : Element msg
     , list : Element msg
+    , progressIndicator : Element msg
     }
 
 
@@ -280,6 +299,9 @@ init =
 
         ( listModel, listMsg ) =
             List.init
+
+        ( progressIndicatorModel, progressIndicatorMsg ) =
+            ProgressIndicator.init
     in
     ( { button = buttonModel
       , select = selectModel
@@ -291,6 +313,7 @@ init =
       , dialog = dialogModel
       , textInput = textInputModel
       , list = listModel
+      , progressIndicator = progressIndicatorModel
       }
     , [ Cmd.map Button buttonMsg
       , Cmd.map Select selectMsg
@@ -302,6 +325,7 @@ init =
       , Cmd.map Dialog dialogMsg
       , Cmd.map TextInput textInputMsg
       , Cmd.map List listMsg
+      , Cmd.map ProgressIndicator progressIndicatorMsg
       ]
         |> Cmd.batch
     )
@@ -379,6 +403,13 @@ upgradeRecord =
         , updateFun = List.update
         , subscriptionsFun = List.subscriptions
         }
+    , progressIndicator =
+        { from = .progressIndicator
+        , to = \model a -> { model | progressIndicator = a }
+        , msgMapper = ProgressIndicator
+        , updateFun = ProgressIndicator.update
+        , subscriptionsFun = ProgressIndicator.subscriptions
+        }
     }
 
 
@@ -414,6 +445,9 @@ update msg model =
 
         List m ->
             updateField .list m
+
+        ProgressIndicator m ->
+            updateField .progressIndicator m
     )
         model
 
@@ -434,6 +468,7 @@ subscriptions model =
     , upgradeRecord.dialog |> subFun
     , upgradeRecord.textInput |> subFun
     , upgradeRecord.list |> subFun
+    , upgradeRecord.progressIndicator |> subFun
     ]
         |> Sub.batch
 
@@ -464,6 +499,8 @@ view msgMapper style model =
         TextInput.view (TextInput >> msgMapper) style (.textInput model)
     , list =
         List.view (List >> msgMapper) style (.list model)
+    , progressIndicator =
+        ProgressIndicator.view (ProgressIndicator >> msgMapper) style (.progressIndicator model)
     }
 
 

--- a/example/src/Data/Style.elm
+++ b/example/src/Data/Style.elm
@@ -7,6 +7,7 @@ import Widget.Style
         , DialogStyle
         , ExpansionPanelStyle
         , LayoutStyle
+        , ProgressIndicatorStyle
         , RowStyle
         , SortTableStyle
         , TabStyle
@@ -28,5 +29,6 @@ type alias Style msg =
     , cardColumn : ColumnStyle msg
     , sortTable : SortTableStyle msg
     , selectButton : ButtonStyle msg
+    , progressIndicator : ProgressIndicatorStyle msg
     , layout : LayoutStyle msg
     }

--- a/example/src/Data/Style/ElmUiFramework.elm
+++ b/example/src/Data/Style/ElmUiFramework.elm
@@ -286,7 +286,14 @@ sortTable =
 
 progressIndicatorStyle : ProgressIndicatorStyle msg
 progressIndicatorStyle =
-    { icon = Element.none
+    { icon =
+        \maybeProgressPercent ->
+            case maybeProgressPercent of
+                Nothing ->
+                    Element.text "Indeterminate progress indicator"
+                Just progressPercent ->
+                    Element.text ("Determinate progress indicator, " ++ String.fromInt progressPercent ++ "% complete")
+
     }
 
 

--- a/example/src/Data/Style/ElmUiFramework.elm
+++ b/example/src/Data/Style/ElmUiFramework.elm
@@ -287,13 +287,13 @@ sortTable =
 progressIndicatorStyle : ProgressIndicatorStyle msg
 progressIndicatorStyle =
     { icon =
-        \maybeProgressPercent ->
-            case maybeProgressPercent of
+        \maybeProgress ->
+            case maybeProgress of
                 Nothing ->
                     Element.text "Indeterminate progress indicator"
 
-                Just progressPercent ->
-                    Element.text ("Determinate progress indicator, " ++ String.fromInt progressPercent ++ "% complete")
+                Just progress ->
+                    Element.text ("Determinate progress indicator, " ++ String.fromFloat progress ++ "completeness")
     }
 
 

--- a/example/src/Data/Style/ElmUiFramework.elm
+++ b/example/src/Data/Style/ElmUiFramework.elm
@@ -291,9 +291,9 @@ progressIndicatorStyle =
             case maybeProgressPercent of
                 Nothing ->
                     Element.text "Indeterminate progress indicator"
+
                 Just progressPercent ->
                     Element.text ("Determinate progress indicator, " ++ String.fromInt progressPercent ++ "% complete")
-
     }
 
 

--- a/example/src/Data/Style/ElmUiFramework.elm
+++ b/example/src/Data/Style/ElmUiFramework.elm
@@ -286,7 +286,7 @@ sortTable =
 
 progressIndicatorStyle : ProgressIndicatorStyle msg
 progressIndicatorStyle =
-    { icon =
+    { containerFunction =
         \maybeProgress ->
             case maybeProgress of
                 Nothing ->

--- a/example/src/Data/Style/ElmUiFramework.elm
+++ b/example/src/Data/Style/ElmUiFramework.elm
@@ -20,6 +20,7 @@ import Widget.Style
         , DialogStyle
         , ExpansionPanelStyle
         , LayoutStyle
+        , ProgressIndicatorStyle
         , RowStyle
         , SnackbarStyle
         , SortTableStyle
@@ -283,6 +284,12 @@ sortTable =
     }
 
 
+progressIndicatorStyle : ProgressIndicatorStyle msg
+progressIndicatorStyle =
+    { icon = Element.none
+    }
+
+
 layout : LayoutStyle msg
 layout =
     { container = []
@@ -335,5 +342,6 @@ style =
     , expansionPanel = expansionPanelStyle
     , dialog = dialog
     , selectButton = buttonStyle
+    , progressIndicator = progressIndicatorStyle
     , layout = layout
     }

--- a/example/src/Data/Style/Material.elm
+++ b/example/src/Data/Style/Material.elm
@@ -52,5 +52,6 @@ style palette =
     , chipButton = Material.chip palette
     , expansionPanel = Material.expansionPanel palette
     , dialog = Material.alertDialog palette
+    , progressIndicator = Material.progressIndicator palette
     , layout = Material.layout palette
     }

--- a/example/src/Data/Style/Template.elm
+++ b/example/src/Data/Style/Template.elm
@@ -23,5 +23,6 @@ style =
     , expansionPanel = Template.expansionPanel "expansionPanel"
     , selectButton = Template.button "selectButton"
     , dialog = Template.dialog "dialog"
+    , progressIndicator = Template.progressIndicator "progressIndicator"
     , layout = Template.layout "layout"
     }

--- a/example/src/Example/ProgressIndicator.elm
+++ b/example/src/Example/ProgressIndicator.elm
@@ -1,0 +1,67 @@
+module Example.ProgressIndicator exposing (Model, Msg, init, subscriptions, update, view)
+
+import Browser
+import Element exposing (Element)
+import Widget
+import Widget.Style exposing (ProgressIndicatorStyle)
+import Widget.Style.Material as Material
+
+
+type alias Style style msg =
+    { style
+        | progressIndicator : ProgressIndicatorStyle msg
+    }
+
+
+materialStyle : Style {} msg
+materialStyle =
+    { progressIndicator = Material.progressIndicator Material.defaultPalette
+    }
+
+
+type Model
+    = ProgressPercent (Maybe Int)
+
+
+type Msg
+    = ChangedProgressPercent (Maybe Int)
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( ProgressPercent Nothing
+    , Cmd.none
+    )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg _ =
+    case msg of
+        ChangedProgressPercent maybeInt ->
+            ( ProgressPercent maybeInt
+            , Cmd.none
+            )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.none
+
+
+{-| You can remove the msgMapper. But by doing so, make sure to also change `msg` to `Msg` in the line below.
+-}
+view : (Msg -> msg) -> Style style msg -> Model -> Element msg
+view msgMapper style (ProgressPercent progressPercent) =
+    Widget.circularProgressIndicator style.progressIndicator
+        { progressPercent = progressPercent
+        }
+
+
+main : Program () Model Msg
+main =
+    Browser.element
+        { init = always init
+        , view = view identity materialStyle >> Element.layout []
+        , update = update
+        , subscriptions = subscriptions
+        }

--- a/example/src/Example/ProgressIndicator.elm
+++ b/example/src/Example/ProgressIndicator.elm
@@ -20,16 +20,16 @@ materialStyle =
 
 
 type Model
-    = MaybeProgressPercent (Maybe Int)
+    = MaybeProgress (Maybe Float)
 
 
 type Msg
-    = ChangedProgressPercent (Maybe Int)
+    = ChangedProgress (Maybe Float)
 
 
 init : ( Model, Cmd Msg )
 init =
-    ( MaybeProgressPercent Nothing
+    ( MaybeProgress Nothing
     , Cmd.none
     )
 
@@ -37,8 +37,8 @@ init =
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg _ =
     case msg of
-        ChangedProgressPercent maybeInt ->
-            ( MaybeProgressPercent maybeInt
+        ChangedProgress maybeFloat ->
+            ( MaybeProgress maybeFloat
             , Cmd.none
             )
 
@@ -51,9 +51,9 @@ subscriptions _ =
 {-| You can remove the msgMapper. But by doing so, make sure to also change `msg` to `Msg` in the line below.
 -}
 view : (Msg -> msg) -> Style style msg -> Model -> Element msg
-view msgMapper style (MaybeProgressPercent maybeProgressPercent) =
+view msgMapper style (MaybeProgress maybeProgress) =
     Widget.circularProgressIndicator style.progressIndicator
-        { maybeProgressPercent = maybeProgressPercent
+        { maybeProgress = maybeProgress
         }
 
 

--- a/example/src/Example/ProgressIndicator.elm
+++ b/example/src/Example/ProgressIndicator.elm
@@ -52,9 +52,7 @@ subscriptions _ =
 -}
 view : (Msg -> msg) -> Style style msg -> Model -> Element msg
 view msgMapper style (MaybeProgress maybeProgress) =
-    Widget.circularProgressIndicator style.progressIndicator
-        { maybeProgress = maybeProgress
-        }
+    Widget.circularProgressIndicator style.progressIndicator maybeProgress
 
 
 main : Program () Model Msg

--- a/example/src/Example/ProgressIndicator.elm
+++ b/example/src/Example/ProgressIndicator.elm
@@ -20,7 +20,7 @@ materialStyle =
 
 
 type Model
-    = ProgressPercent (Maybe Int)
+    = MaybeProgressPercent (Maybe Int)
 
 
 type Msg
@@ -29,7 +29,7 @@ type Msg
 
 init : ( Model, Cmd Msg )
 init =
-    ( ProgressPercent Nothing
+    ( MaybeProgressPercent Nothing
     , Cmd.none
     )
 
@@ -38,7 +38,7 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg _ =
     case msg of
         ChangedProgressPercent maybeInt ->
-            ( ProgressPercent maybeInt
+            ( MaybeProgressPercent maybeInt
             , Cmd.none
             )
 
@@ -51,9 +51,9 @@ subscriptions _ =
 {-| You can remove the msgMapper. But by doing so, make sure to also change `msg` to `Msg` in the line below.
 -}
 view : (Msg -> msg) -> Style style msg -> Model -> Element msg
-view msgMapper style (ProgressPercent progressPercent) =
+view msgMapper style (MaybeProgressPercent maybeProgressPercent) =
     Widget.circularProgressIndicator style.progressIndicator
-        { progressPercent = progressPercent
+        { maybeProgressPercent = maybeProgressPercent
         }
 
 

--- a/example/src/View/Test.elm
+++ b/example/src/View/Test.elm
@@ -515,7 +515,17 @@ list _ style =
 
 progressIndicator : msg -> Style msg -> List ( String, Element msg )
 progressIndicator _ style =
-    [ ( "Circular Progress Indicator"
-      , Widget.circularProgressIndicator style.progressIndicator { progressPercent = Nothing }
+    let
+        determinateIndicators =
+            [ 0, 25, 50, 75, 100 ]
+                |> List.map
+                    (\percent ->
+                        ( "Determinate Progress Indicator, " ++ String.fromInt percent ++ "% complete"
+                          , Widget.circularProgressIndicator style.progressIndicator { maybeProgressPercent = Just percent }
+                        )
+                    )
+    in
+    [ ( "Indeterminate Progress Indicator"
+      , Widget.circularProgressIndicator style.progressIndicator { maybeProgressPercent = Nothing }
       )
-    ]
+    ] ++ determinateIndicators

--- a/example/src/View/Test.elm
+++ b/example/src/View/Test.elm
@@ -517,16 +517,16 @@ progressIndicator : msg -> Style msg -> List ( String, Element msg )
 progressIndicator _ style =
     let
         determinateIndicators =
-            [ 0, 25, 50, 75, 100 ]
+            [ 0, 0.25, 0.50, 0.75, 1 ]
                 |> List.map
-                    (\percent ->
-                        ( "Determinate Progress Indicator, " ++ String.fromInt percent ++ "% complete"
-                        , Widget.circularProgressIndicator style.progressIndicator { maybeProgressPercent = Just percent }
+                    (\completeness ->
+                        ( "Determinate Progress Indicator, completeness " ++ String.fromFloat completeness
+                        , Widget.circularProgressIndicator style.progressIndicator { maybeProgress = Just completeness }
                         )
                     )
     in
     [ ( "Indeterminate Progress Indicator"
-      , Widget.circularProgressIndicator style.progressIndicator { maybeProgressPercent = Nothing }
+      , Widget.circularProgressIndicator style.progressIndicator { maybeProgress = Nothing }
       )
     ]
         ++ determinateIndicators

--- a/example/src/View/Test.elm
+++ b/example/src/View/Test.elm
@@ -521,12 +521,12 @@ progressIndicator _ style =
                 |> List.map
                     (\completeness ->
                         ( "Determinate Progress Indicator, completeness " ++ String.fromFloat completeness
-                        , Widget.circularProgressIndicator style.progressIndicator { maybeProgress = Just completeness }
+                        , Widget.circularProgressIndicator style.progressIndicator (Just completeness)
                         )
                     )
     in
     [ ( "Indeterminate Progress Indicator"
-      , Widget.circularProgressIndicator style.progressIndicator { maybeProgress = Nothing }
+      , Widget.circularProgressIndicator style.progressIndicator Nothing
       )
     ]
         ++ determinateIndicators

--- a/example/src/View/Test.elm
+++ b/example/src/View/Test.elm
@@ -1,4 +1,4 @@
-module View.Test exposing (button, dialog, expansionPanel, list, modal, multiSelect, select, sortTable, tab, textInput)
+module View.Test exposing (button, dialog, expansionPanel, list, modal, multiSelect, progressIndicator, select, sortTable, tab, textInput)
 
 import Data.Style exposing (Style)
 import Element exposing (Element)
@@ -509,5 +509,13 @@ list _ style =
     , ( "Empty List"
       , []
             |> Widget.column style.cardColumn
+      )
+    ]
+
+
+progressIndicator : msg -> Style msg -> List ( String, Element msg )
+progressIndicator _ style =
+    [ ( "Circular Progress Indicator"
+      , Widget.circularProgressIndicator style.progressIndicator { progressPercent = Nothing }
       )
     ]

--- a/example/src/View/Test.elm
+++ b/example/src/View/Test.elm
@@ -521,11 +521,12 @@ progressIndicator _ style =
                 |> List.map
                     (\percent ->
                         ( "Determinate Progress Indicator, " ++ String.fromInt percent ++ "% complete"
-                          , Widget.circularProgressIndicator style.progressIndicator { maybeProgressPercent = Just percent }
+                        , Widget.circularProgressIndicator style.progressIndicator { maybeProgressPercent = Just percent }
                         )
                     )
     in
     [ ( "Indeterminate Progress Indicator"
       , Widget.circularProgressIndicator style.progressIndicator { maybeProgressPercent = Nothing }
       )
-    ] ++ determinateIndicators
+    ]
+        ++ determinateIndicators

--- a/src/Internal/ProgressIndicator.elm
+++ b/src/Internal/ProgressIndicator.elm
@@ -9,4 +9,4 @@ circularProgressIndicator :
     -> Maybe Float
     -> Element msg
 circularProgressIndicator style maybeProgress =
-    style.icon maybeProgress
+    style.containerFunction maybeProgress

--- a/src/Internal/ProgressIndicator.elm
+++ b/src/Internal/ProgressIndicator.elm
@@ -1,0 +1,17 @@
+module Internal.ProgressIndicator exposing (circularProgressIndicator)
+
+import Element exposing (Element)
+import Widget.Style exposing (ProgressIndicatorStyle)
+
+
+circularProgressIndicator :
+    ProgressIndicatorStyle msg
+    -> { progressPercent : Maybe Int }
+    -> Element msg
+circularProgressIndicator style { progressPercent } =
+    -- TODO determinate indicator based on progressPercent
+    style.icon
+
+
+
+-- TODO linear progress indicator

--- a/src/Internal/ProgressIndicator.elm
+++ b/src/Internal/ProgressIndicator.elm
@@ -6,11 +6,11 @@ import Widget.Style exposing (ProgressIndicatorStyle)
 
 circularProgressIndicator :
     ProgressIndicatorStyle msg
-    -> { progressPercent : Maybe Int }
+    -> { maybeProgressPercent : Maybe Int }
     -> Element msg
-circularProgressIndicator style { progressPercent } =
+circularProgressIndicator style { maybeProgressPercent } =
     -- TODO determinate indicator based on progressPercent
-    style.icon
+    style.icon maybeProgressPercent
 
 
 

--- a/src/Internal/ProgressIndicator.elm
+++ b/src/Internal/ProgressIndicator.elm
@@ -6,7 +6,7 @@ import Widget.Style exposing (ProgressIndicatorStyle)
 
 circularProgressIndicator :
     ProgressIndicatorStyle msg
-    -> { maybeProgressPercent : Maybe Int }
+    -> { maybeProgress : Maybe Float }
     -> Element msg
-circularProgressIndicator style { maybeProgressPercent } =
-    style.icon maybeProgressPercent
+circularProgressIndicator style { maybeProgress } =
+    style.icon maybeProgress

--- a/src/Internal/ProgressIndicator.elm
+++ b/src/Internal/ProgressIndicator.elm
@@ -9,9 +9,4 @@ circularProgressIndicator :
     -> { maybeProgressPercent : Maybe Int }
     -> Element msg
 circularProgressIndicator style { maybeProgressPercent } =
-    -- TODO determinate indicator based on progressPercent
     style.icon maybeProgressPercent
-
-
-
--- TODO linear progress indicator

--- a/src/Internal/ProgressIndicator.elm
+++ b/src/Internal/ProgressIndicator.elm
@@ -6,7 +6,7 @@ import Widget.Style exposing (ProgressIndicatorStyle)
 
 circularProgressIndicator :
     ProgressIndicatorStyle msg
-    -> { maybeProgress : Maybe Float }
+    -> Maybe Float
     -> Element msg
-circularProgressIndicator style { maybeProgress } =
+circularProgressIndicator style maybeProgress =
     style.icon maybeProgress

--- a/src/Widget.elm
+++ b/src/Widget.elm
@@ -634,11 +634,18 @@ tab =
 - PROGRESS INDICATOR
 ----------------------------------------------------------}
 
+{-| Progress Indicator widget type
 
+If `maybeProgressPercent` is set to `Nothing`, an indeterminate progress indicator (e.g. spinner) will display.
+If `maybeProgressPercent` is set to `Just Int` (where the `Int` is completion percentage between 0 and 100 inclusive), a determinate progress indicator will visualize the completion percentage.
+
+-}
 type alias ProgressIndicator =
     { maybeProgressPercent : Maybe Int }
 
 
+{-| Displays a circular progress indicator
+-}
 circularProgressIndicator :
     ProgressIndicatorStyle msg
     -> { maybeProgressPercent : Maybe Int }

--- a/src/Widget.elm
+++ b/src/Widget.elm
@@ -119,6 +119,15 @@ You can create you own widgets by sticking widgets types together.
 
 @docs Dialog, ExpansionPanel
 
+
+# Progress Indicator
+
+![ProgressIndicator](TODO)
+
+[Open in Ellie](TODO)
+
+@docs ProgressIndicator, progressIndicator
+
 -}
 
 import Element exposing (Attribute, Element, Length)

--- a/src/Widget.elm
+++ b/src/Widget.elm
@@ -636,19 +636,19 @@ tab =
 
 {-| Progress Indicator widget type
 
-If `maybeProgressPercent` is set to `Nothing`, an indeterminate progress indicator (e.g. spinner) will display.
-If `maybeProgressPercent` is set to `Just Int` (where the `Int` is completion percentage between 0 and 100 inclusive), a determinate progress indicator will visualize the completion percentage.
+If `maybeProgress` is set to `Nothing`, an indeterminate progress indicator (e.g. spinner) will display.
+If `maybeProgress` is set to `Just Float` (where the `Float` is proportion of completeness between 0 and 1 inclusive), a determinate progress indicator will visualize the progress.
 
 -}
 type alias ProgressIndicator =
-    { maybeProgressPercent : Maybe Int }
+    { maybeProgress : Maybe Float }
 
 
 {-| Displays a circular progress indicator
 -}
 circularProgressIndicator :
     ProgressIndicatorStyle msg
-    -> { maybeProgressPercent : Maybe Int }
+    -> { maybeProgress : Maybe Float }
     -> Element msg
 circularProgressIndicator =
     ProgressIndicator.circularProgressIndicator

--- a/src/Widget.elm
+++ b/src/Widget.elm
@@ -627,12 +627,12 @@ tab =
 
 
 type alias ProgressIndicator =
-    { progressPercent : Maybe Int }
+    { maybeProgressPercent : Maybe Int }
 
 
 circularProgressIndicator :
     ProgressIndicatorStyle msg
-    -> { progressPercent : Maybe Int }
+    -> { maybeProgressPercent : Maybe Int }
     -> Element msg
 circularProgressIndicator =
     ProgressIndicator.circularProgressIndicator

--- a/src/Widget.elm
+++ b/src/Widget.elm
@@ -641,14 +641,14 @@ If `maybeProgress` is set to `Just Float` (where the `Float` is proportion of co
 
 -}
 type alias ProgressIndicator =
-    { maybeProgress : Maybe Float }
+    Maybe Float
 
 
 {-| Displays a circular progress indicator
 -}
 circularProgressIndicator :
     ProgressIndicatorStyle msg
-    -> { maybeProgress : Maybe Float }
+    -> Maybe Float
     -> Element msg
 circularProgressIndicator =
     ProgressIndicator.circularProgressIndicator

--- a/src/Widget.elm
+++ b/src/Widget.elm
@@ -9,6 +9,7 @@ module Widget exposing
     , TextInput, textInput
     , Tab, tab
     , Dialog, ExpansionPanel
+    , circularProgressIndicator
     )
 
 {-| This module contains different stateless view functions. No wiring required.
@@ -126,12 +127,13 @@ import Internal.Button as Button
 import Internal.Dialog as Dialog
 import Internal.ExpansionPanel as ExpansionPanel
 import Internal.List as List
+import Internal.ProgressIndicator as ProgressIndicator
 import Internal.Select as Select
 import Internal.SortTable as SortTable
 import Internal.Tab as Tab
 import Internal.TextInput as TextInput
 import Set exposing (Set)
-import Widget.Style exposing (ButtonStyle, ColumnStyle, DialogStyle, ExpansionPanelStyle, RowStyle, SortTableStyle, TabStyle, TextInputStyle)
+import Widget.Style exposing (ButtonStyle, ColumnStyle, DialogStyle, ExpansionPanelStyle, ProgressIndicatorStyle, RowStyle, SortTableStyle, TabStyle, TextInputStyle)
 
 
 
@@ -616,3 +618,21 @@ tab =
             Tab.tab
     in
     fun
+
+
+
+{----------------------------------------------------------
+- PROGRESS INDICATOR
+----------------------------------------------------------}
+
+
+type alias ProgressIndicator =
+    { progressPercent : Maybe Int }
+
+
+circularProgressIndicator :
+    ProgressIndicatorStyle msg
+    -> { progressPercent : Maybe Int }
+    -> Element msg
+circularProgressIndicator =
+    ProgressIndicator.circularProgressIndicator

--- a/src/Widget/Style.elm
+++ b/src/Widget/Style.elm
@@ -1,4 +1,6 @@
-module Widget.Style exposing (ButtonStyle,ColumnStyle, DialogStyle, ExpansionPanelStyle, LayoutStyle, RowStyle, SnackbarStyle, SortTableStyle, TabStyle, TextInputStyle)
+module Widget.Style exposing
+    ( ButtonStyle, ColumnStyle, DialogStyle, ExpansionPanelStyle, LayoutStyle, RowStyle, SnackbarStyle, SortTableStyle, TabStyle, TextInputStyle, ProgressIndicatorStyle
+    )
 
 {-| This module contains style types for every widget.
 
@@ -131,4 +133,9 @@ type alias LayoutStyle msg =
     , searchIcon : Element Never
     , search : List (Attribute msg)
     , searchFill : List (Attribute msg)
+    }
+
+
+type alias ProgressIndicatorStyle msg =
+    { icon : Element msg
     }

--- a/src/Widget/Style.elm
+++ b/src/Widget/Style.elm
@@ -137,5 +137,5 @@ type alias LayoutStyle msg =
 
 
 type alias ProgressIndicatorStyle msg =
-    { icon : Element msg
+    { icon : (Maybe Int -> Element msg)
     }

--- a/src/Widget/Style.elm
+++ b/src/Widget/Style.elm
@@ -136,5 +136,5 @@ type alias LayoutStyle msg =
 
 {-| -}
 type alias ProgressIndicatorStyle msg =
-    { icon : Maybe Float -> Element msg
+    { containerFunction : Maybe Float -> Element msg
     }

--- a/src/Widget/Style.elm
+++ b/src/Widget/Style.elm
@@ -136,5 +136,5 @@ type alias LayoutStyle msg =
 
 {-| -}
 type alias ProgressIndicatorStyle msg =
-    { icon : (Maybe Int -> Element msg)
+    { icon : Maybe Int -> Element msg
     }

--- a/src/Widget/Style.elm
+++ b/src/Widget/Style.elm
@@ -136,5 +136,5 @@ type alias LayoutStyle msg =
 
 {-| -}
 type alias ProgressIndicatorStyle msg =
-    { icon : Maybe Int -> Element msg
+    { icon : Maybe Float -> Element msg
     }

--- a/src/Widget/Style.elm
+++ b/src/Widget/Style.elm
@@ -1,6 +1,4 @@
-module Widget.Style exposing
-    ( ButtonStyle, ColumnStyle, DialogStyle, ExpansionPanelStyle, LayoutStyle, RowStyle, SnackbarStyle, SortTableStyle, TabStyle, TextInputStyle, ProgressIndicatorStyle
-    )
+module Widget.Style exposing (ButtonStyle, ColumnStyle, DialogStyle, ExpansionPanelStyle, LayoutStyle, RowStyle, SnackbarStyle, SortTableStyle, TabStyle, TextInputStyle, ProgressIndicatorStyle)
 
 {-| This module contains style types for every widget.
 
@@ -136,6 +134,7 @@ type alias LayoutStyle msg =
     }
 
 
+{-| -}
 type alias ProgressIndicatorStyle msg =
     { icon : (Maybe Int -> Element msg)
     }

--- a/src/Widget/Style/Material.elm
+++ b/src/Widget/Style/Material.elm
@@ -7,6 +7,7 @@ module Widget.Style.Material exposing
     , alertDialog
     , expansionPanel
     , row, column
+    , progressIndicator
     , snackbar
     , tab, tabButton
     , layout
@@ -42,6 +43,7 @@ You can use the theme by copying the following code:
         , cardColumn : ColumnStyle msg
         , sortTable : SortTableStyle msg
         , selectButton : ButtonStyle msg
+        , progressIndicator : ProgressIndicatorStyle msg
         , layout : LayoutStyle msg
         }
 
@@ -69,6 +71,7 @@ You can use the theme by copying the following code:
         , chipButton = Material.chip palette
         , expansionPanel = Material.expansionPanel palette
         , dialog = Material.alertDialog palette
+        , progressIndicator = Material.progressIndicator palette
         , layout = Material.layout palette
         }
 
@@ -123,6 +126,11 @@ The [List widget](https://material.io/components/lists) is a very complex widget
 @docs row, column
 
 
+# Progress Indicator
+
+@docs progressIndicator
+
+
 # Snackbar
 
 @docs snackbar
@@ -156,6 +164,7 @@ import Widget.Style
         , DialogStyle
         , ExpansionPanelStyle
         , LayoutStyle
+        , ProgressIndicatorStyle
         , RowStyle
         , SnackbarStyle
         , TabStyle
@@ -1197,6 +1206,75 @@ expansionPanel palette =
                     |> fromColor
                     |> Font.color
                 ]
+    }
+
+
+
+{-------------------------------------------------------------------------------
+-- P R O G R E S S   I N D I C A T O R
+-------------------------------------------------------------------------------}
+
+
+indeterminateCircIcon : Color.Color -> List (Attribute msg) -> Element msg
+indeterminateCircIcon color attribs =
+    -- Based on example at https://codepen.io/FezVrasta/pen/oXrgdR
+    Svg.svg
+        [ Svg.Attributes.height "48px"
+        , Svg.Attributes.width "48px"
+        , Svg.Attributes.viewBox "0 0 66 66"
+        , Svg.Attributes.xmlSpace "http://www.w3.org/2000/svg"
+        ]
+        [ Svg.g []
+            [ Svg.animateTransform
+                [ Svg.Attributes.attributeName "transform"
+                , Svg.Attributes.type_ "rotate"
+                , Svg.Attributes.values "0 33 33;270 33 33"
+                , Svg.Attributes.begin "0s"
+                , Svg.Attributes.dur "1.4s"
+                , Svg.Attributes.fill "freeze"
+                , Svg.Attributes.repeatCount "indefinite"
+                ]
+                []
+            , Svg.circle
+                [ Svg.Attributes.fill "none"
+                , Svg.Attributes.stroke (Color.toCssString color)
+                , Svg.Attributes.strokeWidth "5"
+                , Svg.Attributes.strokeLinecap "square"
+                , Svg.Attributes.cx "33"
+                , Svg.Attributes.cy "33"
+                , Svg.Attributes.r "30"
+                , Svg.Attributes.strokeDasharray "187"
+                , Svg.Attributes.strokeDashoffset "610"
+                ]
+                [ Svg.animateTransform
+                    [ Svg.Attributes.attributeName "transform"
+                    , Svg.Attributes.type_ "rotate"
+                    , Svg.Attributes.values "0 33 33;135 33 33;450 33 33"
+                    , Svg.Attributes.begin "0s"
+                    , Svg.Attributes.dur "1.4s"
+                    , Svg.Attributes.fill "freeze"
+                    , Svg.Attributes.repeatCount "indefinite"
+                    ]
+                    []
+                , Svg.animate
+                    [ Svg.Attributes.attributeName "stroke-dashoffset"
+                    , Svg.Attributes.values "187;46.75;187"
+                    , Svg.Attributes.begin "0s"
+                    , Svg.Attributes.dur "1.4s"
+                    , Svg.Attributes.fill "freeze"
+                    , Svg.Attributes.repeatCount "indefinite"
+                    ]
+                    []
+                ]
+            ]
+        ]
+        |> Element.html
+        |> Element.el attribs
+
+
+progressIndicator : Palette -> ProgressIndicatorStyle msg
+progressIndicator palette =
+    { icon = indeterminateCircIcon palette.primary []
     }
 
 

--- a/src/Widget/Style/Material.elm
+++ b/src/Widget/Style/Material.elm
@@ -1272,17 +1272,18 @@ indeterminateCircularIcon color attribs =
         |> Element.el attribs
 
 
-determinateCircularIcon : Color.Color -> List (Attribute msg) -> Int -> Element msg
-determinateCircularIcon color attribs progressPercent =
+determinateCircularIcon : Color.Color -> List (Attribute msg) -> Float -> Element msg
+determinateCircularIcon color attribs progress =
     -- With help from https://css-tricks.com/building-progress-ring-quickly/
     let
         strokeDashoffset =
             let
-                clampedProgPrecent =
-                    clamp 0 100 progressPercent
+                clampedProgress =
+                    clamp 0 1 progress
             in
             -- 188 is circumference of circle in pixels
-            188 - (188 * clampedProgPrecent // 100)
+            188 - (188 * clampedProgress)
+                |> round
     in
     Svg.svg
         [ Svg.Attributes.height "48px"
@@ -1313,13 +1314,13 @@ determinateCircularIcon color attribs progressPercent =
 progressIndicator : Palette -> ProgressIndicatorStyle msg
 progressIndicator palette =
     { icon =
-        \maybeProgressPercent ->
-            case maybeProgressPercent of
+        \maybeProgress ->
+            case maybeProgress of
                 Nothing ->
                     indeterminateCircularIcon palette.primary []
 
-                Just progressPercent ->
-                    determinateCircularIcon palette.primary [] progressPercent
+                Just progress ->
+                    determinateCircularIcon palette.primary [] progress
     }
 
 

--- a/src/Widget/Style/Material.elm
+++ b/src/Widget/Style/Material.elm
@@ -1278,7 +1278,8 @@ determinateCircularIcon color attribs progressPercent =
     let
         strokeDashoffset =
             let
-                clampedProgPrecent = clamp 0 100 progressPercent
+                clampedProgPrecent =
+                    clamp 0 100 progressPercent
             in
             -- 188 is circumference of circle in pixels
             188 - (188 * clampedProgPrecent // 100)
@@ -1316,6 +1317,7 @@ progressIndicator palette =
             case maybeProgressPercent of
                 Nothing ->
                     indeterminateCircularIcon palette.primary []
+
                 Just progressPercent ->
                     determinateCircularIcon palette.primary [] progressPercent
     }

--- a/src/Widget/Style/Material.elm
+++ b/src/Widget/Style/Material.elm
@@ -1313,7 +1313,7 @@ determinateCircularIcon color attribs progress =
 
 progressIndicator : Palette -> ProgressIndicatorStyle msg
 progressIndicator palette =
-    { icon =
+    { containerFunction =
         \maybeProgress ->
             case maybeProgress of
                 Nothing ->

--- a/src/Widget/Style/Material.elm
+++ b/src/Widget/Style/Material.elm
@@ -1272,9 +1272,81 @@ indeterminateCircIcon color attribs =
         |> Element.el attribs
 
 
+determinateCircIcon : Color.Color -> List (Attribute msg) -> Int -> Element msg
+determinateCircIcon color attribs progressPercent =
+    -- With help from https://css-tricks.com/building-progress-ring-quickly/
+    let
+        strokeDashoffset =
+            let
+                clampedProgPrecent = clamp 0 100 progressPercent
+            in
+            -- 188 is circumference of circle in pixels
+            188 - (188 * clampedProgPrecent // 100)
+    in
+    Svg.svg
+        [ Svg.Attributes.height "48px"
+        , Svg.Attributes.width "48px"
+        , Svg.Attributes.viewBox "0 0 66 66"
+        , Svg.Attributes.xmlSpace "http://www.w3.org/2000/svg"
+        ]
+        [ Svg.g []
+            [ {- Svg.animateTransform
+                [ Svg.Attributes.attributeName "transform"
+                , Svg.Attributes.type_ "rotate"
+                , Svg.Attributes.values "0 33 33;270 33 33"
+                , Svg.Attributes.begin "0s"
+                , Svg.Attributes.dur "1.4s"
+                , Svg.Attributes.fill "freeze"
+                , Svg.Attributes.repeatCount "indefinite"
+                ]
+                []
+            , -}Svg.circle
+                [ Svg.Attributes.fill "none"
+                , Svg.Attributes.stroke (Color.toCssString color)
+                , Svg.Attributes.strokeWidth "5"
+                , Svg.Attributes.strokeLinecap "butt"
+                , Svg.Attributes.cx "33"
+                , Svg.Attributes.cy "33"
+                , Svg.Attributes.r "30"
+                , Svg.Attributes.strokeDasharray "188 188"
+                , Svg.Attributes.strokeDashoffset (String.fromInt strokeDashoffset)
+                , Svg.Attributes.transform "rotate(-90 33 33)"
+                ]
+                [ {- Svg.animateTransform
+                    [ Svg.Attributes.attributeName "transform"
+                    , Svg.Attributes.type_ "rotate"
+                    , Svg.Attributes.values "0 33 33;135 33 33;450 33 33"
+                    , Svg.Attributes.begin "0s"
+                    , Svg.Attributes.dur "1.4s"
+                    , Svg.Attributes.fill "freeze"
+                    , Svg.Attributes.repeatCount "indefinite"
+                    ]
+                    []
+                , Svg.animate
+                    [ Svg.Attributes.attributeName "stroke-dashoffset"
+                    , Svg.Attributes.values "187;46.75;187"
+                    , Svg.Attributes.begin "0s"
+                    , Svg.Attributes.dur "1.4s"
+                    , Svg.Attributes.fill "freeze"
+                    , Svg.Attributes.repeatCount "indefinite"
+                    ]
+                    [] -}
+                ]
+            ]
+        ]
+        |> Element.html
+        |> Element.el attribs
+
+
 progressIndicator : Palette -> ProgressIndicatorStyle msg
 progressIndicator palette =
-    { icon = indeterminateCircIcon palette.primary []
+    { icon =
+        \maybeProgressPercent ->
+            case maybeProgressPercent of
+                Nothing ->
+                    indeterminateCircIcon palette.primary []
+                Just progressPercent ->
+                    determinateCircIcon palette.primary [] progressPercent
     }
 
 

--- a/src/Widget/Style/Material.elm
+++ b/src/Widget/Style/Material.elm
@@ -1215,8 +1215,8 @@ expansionPanel palette =
 -------------------------------------------------------------------------------}
 
 
-indeterminateCircIcon : Color.Color -> List (Attribute msg) -> Element msg
-indeterminateCircIcon color attribs =
+indeterminateCircularIcon : Color.Color -> List (Attribute msg) -> Element msg
+indeterminateCircularIcon color attribs =
     -- Based on example at https://codepen.io/FezVrasta/pen/oXrgdR
     Svg.svg
         [ Svg.Attributes.height "48px"
@@ -1272,8 +1272,8 @@ indeterminateCircIcon color attribs =
         |> Element.el attribs
 
 
-determinateCircIcon : Color.Color -> List (Attribute msg) -> Int -> Element msg
-determinateCircIcon color attribs progressPercent =
+determinateCircularIcon : Color.Color -> List (Attribute msg) -> Int -> Element msg
+determinateCircularIcon color attribs progressPercent =
     -- With help from https://css-tricks.com/building-progress-ring-quickly/
     let
         strokeDashoffset =
@@ -1290,17 +1290,7 @@ determinateCircIcon color attribs progressPercent =
         , Svg.Attributes.xmlSpace "http://www.w3.org/2000/svg"
         ]
         [ Svg.g []
-            [ {- Svg.animateTransform
-                [ Svg.Attributes.attributeName "transform"
-                , Svg.Attributes.type_ "rotate"
-                , Svg.Attributes.values "0 33 33;270 33 33"
-                , Svg.Attributes.begin "0s"
-                , Svg.Attributes.dur "1.4s"
-                , Svg.Attributes.fill "freeze"
-                , Svg.Attributes.repeatCount "indefinite"
-                ]
-                []
-            , -}Svg.circle
+            [ Svg.circle
                 [ Svg.Attributes.fill "none"
                 , Svg.Attributes.stroke (Color.toCssString color)
                 , Svg.Attributes.strokeWidth "5"
@@ -1312,26 +1302,7 @@ determinateCircIcon color attribs progressPercent =
                 , Svg.Attributes.strokeDashoffset (String.fromInt strokeDashoffset)
                 , Svg.Attributes.transform "rotate(-90 33 33)"
                 ]
-                [ {- Svg.animateTransform
-                    [ Svg.Attributes.attributeName "transform"
-                    , Svg.Attributes.type_ "rotate"
-                    , Svg.Attributes.values "0 33 33;135 33 33;450 33 33"
-                    , Svg.Attributes.begin "0s"
-                    , Svg.Attributes.dur "1.4s"
-                    , Svg.Attributes.fill "freeze"
-                    , Svg.Attributes.repeatCount "indefinite"
-                    ]
-                    []
-                , Svg.animate
-                    [ Svg.Attributes.attributeName "stroke-dashoffset"
-                    , Svg.Attributes.values "187;46.75;187"
-                    , Svg.Attributes.begin "0s"
-                    , Svg.Attributes.dur "1.4s"
-                    , Svg.Attributes.fill "freeze"
-                    , Svg.Attributes.repeatCount "indefinite"
-                    ]
-                    [] -}
-                ]
+                []
             ]
         ]
         |> Element.html
@@ -1344,9 +1315,9 @@ progressIndicator palette =
         \maybeProgressPercent ->
             case maybeProgressPercent of
                 Nothing ->
-                    indeterminateCircIcon palette.primary []
+                    indeterminateCircularIcon palette.primary []
                 Just progressPercent ->
-                    determinateCircIcon palette.primary [] progressPercent
+                    determinateCircularIcon palette.primary [] progressPercent
     }
 
 

--- a/src/Widget/Style/Template.elm
+++ b/src/Widget/Style/Template.elm
@@ -1,7 +1,6 @@
 module Widget.Style.Template exposing
     ( box, decoration, icon
-    , button, column, dialog, expansionPanel, layout, row, snackbar, sortTable, tab, textInput
-    , progressIndicator
+    , button, column, dialog, expansionPanel, layout, progressIndicator, row, snackbar, sortTable, tab, textInput
     )
 
 {-| ![Example using the Template style](https://orasund.github.io/elm-ui-widgets/assets/template-style.png)
@@ -346,8 +345,7 @@ sortTable string =
 ```
 progressIndicator : String -> ProgressIndicatorStyle msg
 progressIndicator string =
-    { track = box <| string ++ ":track"
-    , indicator = box <| string ++ ":box"
+    { icon = (\_ -> icon <| string ++ ":icon")
     }
 ```
 

--- a/src/Widget/Style/Template.elm
+++ b/src/Widget/Style/Template.elm
@@ -1,6 +1,7 @@
 module Widget.Style.Template exposing
     ( box, decoration, icon
     , button, column, dialog, expansionPanel, layout, row, snackbar, sortTable, tab, textInput
+    , progressIndicator
     )
 
 {-| ![Example using the Template style](https://orasund.github.io/elm-ui-widgets/assets/template-style.png)
@@ -69,6 +70,7 @@ import Widget.Style
         , DialogStyle
         , ExpansionPanelStyle
         , LayoutStyle
+        , ProgressIndicatorStyle
         , RowStyle
         , SnackbarStyle
         , SortTableStyle
@@ -336,6 +338,23 @@ sortTable string =
     , ascIcon = icon <| string ++ ":ascIcon"
     , descIcon = icon <| string ++ ":descIcon"
     , defaultIcon = icon <| string ++ ":defaultIcon"
+    }
+
+
+{-|
+
+```
+progressIndicator : String -> ProgressIndicatorStyle msg
+progressIndicator string =
+    { track = box <| string ++ ":track"
+    , indicator = box <| string ++ ":box"
+    }
+```
+
+-}
+progressIndicator : String -> ProgressIndicatorStyle msg
+progressIndicator string =
+    { icon = icon <| string ++ ":icon"
     }
 
 

--- a/src/Widget/Style/Template.elm
+++ b/src/Widget/Style/Template.elm
@@ -354,7 +354,7 @@ progressIndicator string =
 -}
 progressIndicator : String -> ProgressIndicatorStyle msg
 progressIndicator string =
-    { icon = icon <| string ++ ":icon"
+    { icon = (\_ -> icon <| string ++ ":icon")
     }
 
 

--- a/src/Widget/Style/Template.elm
+++ b/src/Widget/Style/Template.elm
@@ -352,7 +352,7 @@ progressIndicator string =
 -}
 progressIndicator : String -> ProgressIndicatorStyle msg
 progressIndicator string =
-    { icon = (\_ -> icon <| string ++ ":icon")
+    { containerFunction = (\_ -> icon <| string ++ ":icon")
     }
 
 


### PR DESCRIPTION
# Description

Solves issue #11. Adds circular progress indicators, both indeterminate (animated spinner showing task in progress) and determinate (circular bar showing how much of a task is complete). I did not implement linear progress indicators in this PR, leaving that for another time if there is need/interest.

# Checklist for new Widget

* [x] Checked out the Material design specification of the widget
* [x] Added constructors and Widgets Type in `src/Internal/[Your Widget].elm`
* [x] Added Style Type in `src/Widget/Style.elm`
* [x] In `src/Widget.elm`:
  * [x] Added a copy of the Widget Type
  * [x] Added a copy of each constructor
  * [x] Linked each constructor to its representative in `src/Internal/[You Widget].elm`
  * [x] Replaced the Style Type in the type signiture of each constructor with its definition
  * [x] Added Documentation
* [x] Added a Template style in `src/Widget/Style/Template.elm`

**Optional:**
* [x] Added a Material design style in `src/Widget/Style/Material.elm`
* [ ] Added a Ellie to the docs (+ copied it into `example/src/Example/[Your Widget].elm`)
