### PR TITLE
Add option to force menu as a sidebar

### DIFF
--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -317,6 +317,7 @@ view model =
                                         |> Array.get int
                                         |> Maybe.map JumpTo
                                 )
+                    , forceMenuSidebar = False
                     , actions =
                         [ { onPress = Just <| Load "https://package.elm-lang.org/packages/Orasund/elm-ui-widgets/latest/"
                           , text = "Docs"

--- a/src/Widget/Layout.elm
+++ b/src/Widget/Layout.elm
@@ -94,6 +94,7 @@ view :
         , layout : Layout msg
         , title : Element msg
         , menu : Select msg
+        , forceMenuSidebar : Bool
         , search :
             Maybe
                 { onChange : String -> msg
@@ -105,7 +106,7 @@ view :
         }
     -> Element msg
     -> Html msg
-view style { search, title, onChangedSidebar, menu, actions, window, dialog, layout } content =
+view style { search, title, onChangedSidebar, menu, forceMenuSidebar, actions, window, dialog, layout } content =
     let
         deviceClass : DeviceClass
         deviceClass =
@@ -143,6 +144,7 @@ view style { search, title, onChangedSidebar, menu, actions, window, dialog, lay
                 (deviceClass == Phone)
                     || (deviceClass == Tablet)
                     || ((menu.options |> List.length) > 5)
+                    || forceMenuSidebar
                then
                 [ Widget.iconButton style.menuButton
                     { onPress = Just <| onChangedSidebar <| Just LeftSheet


### PR DESCRIPTION
# Description

This adds a field to the configuration taken by `Widget.Layout.view` to force rendering the menu as a sidebar.

**Pull request solving issue #15 .**

_not a new widget_

**Optional:**
* [ ] Added a Material design style in `src/Widget/Style/Material.elm`
* [ ] Added a Ellie to the docs (+ copied it into `example/src/Example/[Your Widget].elm`)
