### PR TITLE
Update elm-heroicons dependency from jasonliang512 to jasonliang-dev

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -23,7 +23,7 @@
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0",
         "elm-community/intdict": "3.0.0 <= v < 4.0.0",
-        "jasonliang512/elm-heroicons": "1.0.2 <= v < 2.0.0",
+        "jasonliang-dev/elm-heroicons": "1.0.2 <= v < 2.0.0",
         "mdgriffith/elm-ui": "1.1.6 <= v < 2.0.0",
         "noahzgordon/elm-color-extra": "1.0.2 <= v < 2.0.0",
         "turboMaCk/queue": "1.0.2 <= v < 2.0.0",


### PR DESCRIPTION
Jason changed his GitHub username, and this broke the Elm compiler's ability to download the package he maintains (which elm-ui-widgets depends on).

More background here:
- https://gitlab.com/exosphere/exosphere/-/issues/375#note_415295880
- Same thing happened for murmur3: https://discourse.elm-lang.org/t/skinney-murmur3-not-downloading/6285

A new package was just published, this PR updates elm-ui-widgets to use it, which will un-break everything that depends on elm-ui-widgets.