### PR TITLE
update the pull_request_template with the new explorer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,4 +23,4 @@ _Please only open Pull Requests for existing issues._
   * [ ] run `elm-verify-examples && elm-test` to test the example
 
 **Optional:**
-* [ ] Added an Example in `example/src/Example/[Your Widget].elm`
+* [ ] Added a Page in `explorer/src/Page/[Your Widget].elm` and added it to `explorer/src/Main.elm`


### PR DESCRIPTION
The pull request template is still mentioning the former example app. This PR fixes it.